### PR TITLE
add diff generation

### DIFF
--- a/applications/logs.go
+++ b/applications/logs.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kenji-yamane/mgr8/drivers"
+	"github.com/kenji-yamane/mgr8/domain"
 )
 
-func GetPreviousMigrationNumber(driver drivers.Driver) (int, error) {
+func GetPreviousMigrationNumber(driver domain.Driver) (int, error) {
 	hasTables, err := driver.HasBaseTable()
 
 	if err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/kenji-yamane/mgr8/applications"
-	"github.com/kenji-yamane/mgr8/drivers"
+	"github.com/kenji-yamane/mgr8/domain"
 )
 
 type apply struct{}
 
-func (a *apply) execute(args []string, databaseURL string, driver drivers.Driver) error {
+func (a *apply) execute(args []string, databaseURL string, driver domain.Driver) error {
 	folderName := args[0]
 	return driver.ExecuteTransaction(databaseURL, func() error {
 		previousMigrationNumber, err := applications.GetPreviousMigrationNumber(driver)
@@ -35,7 +35,7 @@ func (a *apply) execute(args []string, databaseURL string, driver drivers.Driver
 	})
 }
 
-func (a *apply) runFolderMigrations(folderName string, previousMigrationNumber int, driver drivers.Driver) (int, error) {
+func (a *apply) runFolderMigrations(folderName string, previousMigrationNumber int, driver domain.Driver) (int, error) {
 	latestMigrationNumber := 0
 	items, err := ioutil.ReadDir(folderName)
 	if err != nil {
@@ -88,7 +88,7 @@ func (a *apply) runFolderMigrations(folderName string, previousMigrationNumber i
 	return latestMigrationNumber, nil
 }
 
-func (a *apply) applyMigrationScript(driver drivers.Driver, scriptName string) error {
+func (a *apply) applyMigrationScript(driver domain.Driver, scriptName string) error {
 	fmt.Printf("Applying file %s\n", scriptName)
 	content, err := os.ReadFile(scriptName)
 	if err != nil {

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -9,10 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var defaultDriverName = string(domain.DefaultDriver)
+var defaultDriverName = string(drivers.Postgres)
 
 type CommandExecutor interface {
-	execute(args []string, databaseURL string, driver drivers.Driver) error
+	execute(args []string, databaseURL string, driver domain.Driver) error
 }
 
 type Command struct {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kenji-yamane/mgr8/drivers"
+	"github.com/kenji-yamane/mgr8/domain"
 )
 
 type generate struct{}
 
-func (g *generate) execute(args []string, databaseURL string, driver drivers.Driver) error {
+func (g *generate) execute(args []string, databaseURL string, driver domain.Driver) error {
 	fileName := args[0]
 	content, err := os.ReadFile(fileName)
 	if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -6,12 +6,12 @@ import (
 	"path"
 
 	"github.com/kenji-yamane/mgr8/applications"
-	"github.com/kenji-yamane/mgr8/drivers"
+	"github.com/kenji-yamane/mgr8/domain"
 )
 
 type validate struct{}
 
-func (v *validate) execute(args []string, databaseURL string, driver drivers.Driver) error {
+func (v *validate) execute(args []string, databaseURL string, driver domain.Driver) error {
 	folderName := args[0]
 	return driver.ExecuteTransaction(databaseURL, func() error {
 		previousMigrationNumber, err := applications.GetPreviousMigrationNumber(driver)
@@ -25,7 +25,7 @@ func (v *validate) execute(args []string, databaseURL string, driver drivers.Dri
 	})
 }
 
-func validateFolderMigrations(folderName string, previousMigrationNumber int, driver drivers.Driver) (int, error) {
+func validateFolderMigrations(folderName string, previousMigrationNumber int, driver domain.Driver) (int, error) {
 	items, err := ioutil.ReadDir(folderName)
 	if err != nil {
 		return 0, err
@@ -55,7 +55,7 @@ func validateFolderMigrations(folderName string, previousMigrationNumber int, dr
 	return 0, nil
 }
 
-func validateFileMigration(version int, fileName string, driver drivers.Driver) (bool, error) {
+func validateFileMigration(version int, fileName string, driver domain.Driver) (bool, error) {
 	hash_file, err := applications.GetSqlHash(fileName)
 	if err != nil {
 		return false, err

--- a/domain/column_diff.go
+++ b/domain/column_diff.go
@@ -1,0 +1,21 @@
+package domain
+
+type CreateColumnDiff struct {
+	tableName string
+	column *Column
+}
+
+func NewCreateColumnDiff(tableName string, column *Column) *CreateColumnDiff {
+	return &CreateColumnDiff{tableName: tableName, column: column}
+}
+
+
+type DropColumnDiff struct {
+	tableName string
+	columnName string
+}
+
+func NewDropColumnDiff(tableName string, columnName string) *DropColumnDiff {
+	return &DropColumnDiff{tableName: tableName, columnName: columnName}
+}
+

--- a/domain/column_diff.go
+++ b/domain/column_diff.go
@@ -2,6 +2,7 @@ package domain
 
 type CreateColumnDiff struct {
 	tableName string
+	columnName string
 	column *Column
 }
 
@@ -9,6 +10,13 @@ func NewCreateColumnDiff(tableName string, column *Column) *CreateColumnDiff {
 	return &CreateColumnDiff{tableName: tableName, column: column}
 }
 
+func (d *CreateColumnDiff) Up(deparser Deparser) string{
+	return deparser.AddColumn()
+}
+
+func (d *CreateColumnDiff) Down(deparser Deparser) string{
+	return deparser.DropColumn(d.tableName, d.columnName)
+}
 
 type DropColumnDiff struct {
 	tableName string
@@ -19,3 +27,10 @@ func NewDropColumnDiff(tableName string, columnName string) *DropColumnDiff {
 	return &DropColumnDiff{tableName: tableName, columnName: columnName}
 }
 
+func (d *DropColumnDiff) Up(deparser Deparser) string{
+	return deparser.DropColumn(d.tableName, d.columnName)
+}
+
+func (d *DropColumnDiff) Down(deparser Deparser) string{
+	return deparser.AddColumn()
+}

--- a/domain/constants.go
+++ b/domain/constants.go
@@ -1,11 +1,6 @@
 package domain
 
-type Driver string
 
 const (
-	MySql         Driver = "mysql"
-	Postgres      Driver = "postgres"
-	DefaultDriver Driver = Postgres
-
 	LogsTableName string = "migration_log"
 )

--- a/domain/diff.go
+++ b/domain/diff.go
@@ -1,6 +1,9 @@
 package domain
 
-type Diff interface{ }
+type Diff interface{
+	Up(driver Deparser) string
+	Down(driver Deparser) string
+}
 
 func (s *Schema) Diff(originalSchema *Schema) []Diff {
 	diffsQueue := []Diff{}
@@ -14,9 +17,9 @@ func (s *Schema) Diff(originalSchema *Schema) []Diff {
 		}
 	}
 
-	for tableName := range originalSchema.Tables {
+	for tableName, table := range originalSchema.Tables {
 		if _, ok := s.Tables[tableName]; !ok {
-			diffsQueue = append(diffsQueue, NewDropTableDiff(tableName))
+			diffsQueue = append(diffsQueue, NewDropTableDiff(table))
 		}
 	}
 

--- a/domain/diff.go
+++ b/domain/diff.go
@@ -1,17 +1,49 @@
 package domain
 
-type SchemaDiff struct{}
-type TableDiff struct{}
-type ColumnDiff struct{}
+type Diff interface{ }
 
-func (s *Schema) Diff(originalSchema *Schema) *SchemaDiff {
-	return nil
+func (s *Schema) Diff(originalSchema *Schema) []Diff {
+	diffsQueue := []Diff{}
+
+	for tableName, table := range s.Tables {
+		originalTable, originalHasTable := originalSchema.Tables[tableName]
+		if !originalHasTable {
+			diffsQueue = append(diffsQueue, NewCreateTableDiff(table))
+		} else {
+			diffsQueue = append(diffsQueue, table.Diff(originalTable)...)
+		}
+	}
+
+	for tableName := range originalSchema.Tables {
+		if _, ok := s.Tables[tableName]; !ok {
+			diffsQueue = append(diffsQueue, NewDropTableDiff(tableName))
+		}
+	}
+
+	return diffsQueue
 }
 
-func (t *Table) Diff(originalTable *Schema) *TableDiff {
-	return nil
+func (t *Table) Diff(originalTable *Table) []Diff {
+	diffsQueue := []Diff{}
+
+	for columnName, column := range t.Columns {
+		originalColumn, originalHasColumn := originalTable.Columns[columnName]
+		if !originalHasColumn {
+			diffsQueue = append(diffsQueue, NewCreateColumnDiff(t.Name, column))
+		} else {
+			diffsQueue = append(diffsQueue, column.Diff(originalColumn)...)
+		}
+	}
+
+	for columnName := range originalTable.Columns {
+		if _, ok := t.Columns[columnName]; !ok {
+			diffsQueue = append(diffsQueue, NewDropColumnDiff(t.Name, columnName))
+		}
+	}
+
+	return diffsQueue
 }
 
-func (t *Column) Diff(originalColumn *Schema) *ColumnDiff {
+func (t *Column) Diff(originalColumn *Column) []Diff {
 	return nil
 }

--- a/domain/diff_test.go
+++ b/domain/diff_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Schema Diff", func() {
 				diffQueue := newSchema.Diff(oldSchema)
 				Expect(diffQueue).To(HaveLen(4))
 				Expect(diffQueue).To(ContainElements(
-					NewDropTableDiff("old_table"),
+					NewDropTableDiff(NewTable("old_table", map[string]*Column{})),
 					NewDropColumnDiff("kept_table", "old_column"),
 					NewCreateTableDiff( NewTable("new_table", map[string]*Column{})),
 					NewCreateColumnDiff("kept_table", &Column{}),

--- a/domain/diff_test.go
+++ b/domain/diff_test.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	)
+
+var _ = Describe("Schema Diff", func() {
+	Context("Generate Diff", func() {
+		When("Table has all data types", func() {
+			It("Parses each of them", func() {
+				oldSchema := &Schema{
+					Tables: map[string]*Table{
+						"old_table": NewTable("old_table", map[string]*Column{}),
+						"kept_table": NewTable("kept_table", map[string]*Column{
+							"old_column": &Column{},
+							"kept_column": &Column{},
+						}),
+					},
+					Views:  nil,
+				}
+				newSchema := &Schema{
+					Tables: map[string]*Table{
+						"new_table": NewTable("new_table", map[string]*Column{}),
+						"kept_table": NewTable("kept_table", map[string]*Column{
+							"kept_column": &Column{},
+							"new_column": &Column{},
+						}),
+					},
+					Views:  nil,
+				}
+
+				diffQueue := newSchema.Diff(oldSchema)
+				Expect(diffQueue).To(HaveLen(4))
+				Expect(diffQueue).To(ContainElements(
+					NewDropTableDiff("old_table"),
+					NewDropColumnDiff("kept_table", "old_column"),
+					NewCreateTableDiff( NewTable("new_table", map[string]*Column{})),
+					NewCreateColumnDiff("kept_table", &Column{}),
+					))
+			})
+		})
+	})
+})

--- a/domain/domain_suite_test.go
+++ b/domain/domain_suite_test.go
@@ -1,0 +1,16 @@
+package domain
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMySqlDriver(t *testing.T) {
+	_t = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Domain Test Suite")
+}
+
+var _t *testing.T

--- a/domain/driver.go
+++ b/domain/driver.go
@@ -1,0 +1,26 @@
+package domain
+
+type Driver interface {
+	ExecuteTransaction(url string, f func() error) error
+
+	Execute(statements []string) error
+	GetLatestMigration() (int, error)
+	GetVersionHashing(version int) (string, error)
+	InsertLatestMigration(int, string, string, string) error
+	CreateBaseTable() error
+	HasBaseTable() (bool, error)
+
+	ParseMigration(scriptFile string) (*Schema, error)
+	Deparser() Deparser
+}
+
+type Deparser interface {
+	CreateTable(table *Table) string
+	DropTable(tableName string) string
+
+	AddColumn() string
+	DropColumn(tableName, columnName string) string
+
+	MakeColumnNotNull(tableName, columnName string) string
+	UnmakeColumnNotNull(tableName, columnName string) string
+}

--- a/domain/schema.go
+++ b/domain/schema.go
@@ -6,7 +6,12 @@ type Schema struct {
 }
 
 type Table struct {
+	Name string
 	Columns map[string]*Column
+}
+
+func NewTable(name string, columns map[string]*Column) *Table {
+	return &Table{Name: name, Columns: columns}
 }
 
 type Column struct {

--- a/domain/table_diff.go
+++ b/domain/table_diff.go
@@ -8,12 +8,27 @@ func NewCreateTableDiff(table *Table) *CreateTableDiff {
 	return &CreateTableDiff{table: table}
 }
 
+func (d *CreateTableDiff) Up(deparser Deparser) string{
+	return deparser.CreateTable(d.table)
+}
+
+func (d *CreateTableDiff) Down(deparser Deparser) string{
+	return deparser.DropTable(d.table.Name)
+}
+
 type DropTableDiff struct {
-	tableName string
+	table *Table
 }
 
-func NewDropTableDiff(tableName string) *DropTableDiff {
-	return &DropTableDiff{tableName: tableName}
+func NewDropTableDiff(table *Table) *DropTableDiff {
+	return &DropTableDiff{table: table}
 }
 
+func (d *DropTableDiff) Up(deparser Deparser) string{
+	return deparser.DropTable(d.table.Name)
+}
+
+func (d *DropTableDiff) Down(deparser Deparser) string{
+	return deparser.CreateTable(d.table)
+}
 

--- a/domain/table_diff.go
+++ b/domain/table_diff.go
@@ -1,0 +1,19 @@
+package domain
+
+type CreateTableDiff struct {
+	table *Table
+}
+
+func NewCreateTableDiff(table *Table) *CreateTableDiff {
+	return &CreateTableDiff{table: table}
+}
+
+type DropTableDiff struct {
+	tableName string
+}
+
+func NewDropTableDiff(tableName string) *DropTableDiff {
+	return &DropTableDiff{tableName: tableName}
+}
+
+

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -8,25 +8,19 @@ import (
 	"github.com/kenji-yamane/mgr8/drivers/postgres"
 )
 
-type Driver interface {
-	ExecuteTransaction(url string, f func() error) error
+type DriverName string
 
-	Execute(statements []string) error
-	GetLatestMigration() (int, error)
-	GetVersionHashing(version int) (string, error)
-	InsertLatestMigration(int, string, string, string) error
-	CreateBaseTable() error
-	HasBaseTable() (bool, error)
+const (
+	MySql         DriverName = "mysql"
+	Postgres      DriverName = "postgres"
+)
 
-	ParseMigration(scriptFile string) (*domain.Schema, error)
-}
-
-func GetDriver(driverName string) (Driver, error) {
-	driver := domain.Driver(driverName)
+func GetDriver(driverName string) (domain.Driver, error) {
+	driver := DriverName(driverName)
 	switch driver {
-	case domain.Postgres:
+	case Postgres:
 		return postgres.NewPostgresDriver(), nil
-	case domain.MySql:
+	case MySql:
 		return mysql.NewMySqlDriver(), nil
 	}
 	return nil, fmt.Errorf("inexistent driver %s", driverName)

--- a/drivers/mysql/deparser.go
+++ b/drivers/mysql/deparser.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/kenji-yamane/mgr8/domain"
+)
+
+type deparser struct { }
+
+func (d *deparser) CreateTable(table *domain.Table) string {
+	// TODO: how to mount this string?
+	return ""
+}
+
+func (d *deparser) DropTable(tableName string) string {
+	return fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)
+}
+
+func (d *deparser) AddColumn() string {
+	// TODO
+	return ""
+}
+
+func (d *deparser) DropColumn(tableName, columnName string) string {
+	return fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", tableName, columnName)
+}
+func (d *deparser) MakeColumnNotNull(tableName, columnName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL", tableName, columnName)
+}
+
+func (d *deparser) UnmakeColumnNotNull(tableName, columnName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL", tableName, columnName)
+}

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -38,6 +38,7 @@ var _ = Describe("MySql Driver", func() {
 				Expect(schema).To(Equal(&domain.Schema{
 					Tables: map[string]*domain.Table{
 						"users": {
+							Name: "users",
 							Columns: map[string]*domain.Column{
 								"phone":         {Datatype: "varchar", IsNotNull: false, Parameters: map[string]interface{}{"size": 11}},
 								"social_number": {Datatype: "varchar", IsNotNull: false, Parameters: map[string]interface{}{"size": 9}},

--- a/drivers/mysql/parser.go
+++ b/drivers/mysql/parser.go
@@ -23,6 +23,10 @@ func NewMySqlDriver() *mySqlDriver {
 	return &mySqlDriver{}
 }
 
+func (d *mySqlDriver) Deparser() domain.Deparser {
+	return &deparser{}
+}
+
 func (d *mySqlDriver) Execute(statements []string) error {
 	for _, stmt := range statements {
 		_, err := d.tx.Exec(stmt)

--- a/drivers/mysql/parser.go
+++ b/drivers/mysql/parser.go
@@ -126,7 +126,7 @@ func (x *extractor) Enter(in ast.Node) (ast.Node, bool) {
 	switch in.(type) {
 	case *ast.CreateTableStmt:
 		createStmt := in.(*ast.CreateTableStmt)
-		x.tables[createStmt.Table.Name.O] = x.parseTable(createStmt)
+		x.tables[createStmt.Table.Name.O] = x.parseTable(createStmt.Table.Name.O, createStmt)
 	case *ast.CreateViewStmt:
 		createStmt := in.(*ast.CreateViewStmt)
 		x.views[createStmt.ViewName.Name.O] = x.parseView(createStmt)
@@ -134,13 +134,14 @@ func (x *extractor) Enter(in ast.Node) (ast.Node, bool) {
 	return in, false
 }
 
-func (x *extractor) parseTable(stmt *ast.CreateTableStmt) *domain.Table {
+func (x *extractor) parseTable(tableName string, stmt *ast.CreateTableStmt) *domain.Table {
 	columns := make(map[string]*domain.Column)
 
 	for _, c := range stmt.Cols {
 		columns[c.Name.Name.O] = x.parseColumn(c)
 	}
 	return &domain.Table{
+		Name: tableName,
 		Columns: columns,
 	}
 }

--- a/drivers/postgres/deparser.go
+++ b/drivers/postgres/deparser.go
@@ -1,0 +1,34 @@
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/kenji-yamane/mgr8/domain"
+)
+
+type deparser struct { }
+
+func (d *deparser) CreateTable(table *domain.Table) string {
+	// TODO: how to mount this string?
+	return ""
+}
+
+func (d *deparser) DropTable(tableName string) string {
+	return fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)
+}
+
+func (d *deparser) AddColumn() string {
+	// TODO
+	return ""
+}
+
+func (d *deparser) DropColumn(tableName, columnName string) string {
+	return fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", tableName, columnName)
+}
+func (d *deparser) MakeColumnNotNull(tableName, columnName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL", tableName, columnName)
+}
+
+func (d *deparser) UnmakeColumnNotNull(tableName, columnName string) string {
+	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL", tableName, columnName)
+}

--- a/drivers/postgres/parser.go
+++ b/drivers/postgres/parser.go
@@ -116,7 +116,7 @@ func (d *postgresDriver) ParseMigration(scriptFile string) (*domain.Schema, erro
 		case *pg_query.Node_CreateStmt:
 			parsedStatement := statement.Stmt.GetCreateStmt()
 			tableName := parsedStatement.Relation.Relname
-			tables[tableName] = d.parseTable(parsedStatement)
+			tables[tableName] = d.parseTable(tableName, parsedStatement)
 		case *pg_query.Node_ViewStmt:
 			parsedStatement := statement.Stmt.GetViewStmt()
 			viewName := parsedStatement.View.Relname
@@ -132,13 +132,14 @@ func (d *postgresDriver) ParseMigration(scriptFile string) (*domain.Schema, erro
 	}, nil
 }
 
-func (d *postgresDriver) parseTable(parsedStatement *pg_query.CreateStmt) *domain.Table {
+func (d *postgresDriver) parseTable(tableName string, parsedStatement *pg_query.CreateStmt) *domain.Table {
 	columns := make(map[string]*domain.Column)
 	for _, elts := range parsedStatement.TableElts {
 		columnDefinition := elts.GetColumnDef()
 		columns[columnDefinition.Colname] = d.parseColumn(columnDefinition)
 	}
 	return &domain.Table{
+		Name: tableName,
 		Columns: columns,
 	}
 }

--- a/drivers/postgres/parser.go
+++ b/drivers/postgres/parser.go
@@ -21,6 +21,10 @@ func NewPostgresDriver() *postgresDriver {
 	return &postgresDriver{}
 }
 
+func (d *postgresDriver) Deparser() domain.Deparser{
+	return &deparser{}
+}
+
 func (d *postgresDriver) Execute(statements []string) error {
 	for _, stmt := range statements {
 		_, err := d.tx.Exec(stmt)

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Postgres Driver", func() {
 				Expect(schema).To(Equal(&domain.Schema{
 					Tables: map[string]*domain.Table{
 						"users": {
+							Name: "users",
 							Columns: map[string]*domain.Column{
 								"social_number": {Datatype: "varchar", IsNotNull: false, Parameters: map[string]interface{}{"size": int32(9)}},
 								"phone":         {Datatype: "varchar", IsNotNull: false, Parameters: map[string]interface{}{"size": int32(11)}},

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,27 @@ require (
 	github.com/pingcap/parser v0.0.0-20190120153311-05caf0a5ea61
 	github.com/pingcap/tidb v0.0.0-20190108123336-c68ee7318319
 )
+
+require (
+	github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f // indirect
+	github.com/cznic/mathutil v0.0.0-20181021201202-eba54fb065b7 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-ole/go-ole v1.2.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pingcap/errors v0.11.0 // indirect
+	github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
+	github.com/shirou/gopsutil v2.18.10+incompatible // indirect
+	github.com/sirupsen/logrus v1.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)


### PR DESCRIPTION
- Add Diff generation and test
- Move the knowledge that there are Postgres and MySQL implementations to the drivers package, since it's his and not the domain's package concern.
- In the other hand, knowledge of the **definition** of a driver is part of the domain (while its **implementations** are not). Thus, the driver definition was moved to the domain.
- Create the Diff interface, which is implemented by any structs with Up and Down methods.
- These methods call deparsers that know how to translate it as DDL code.
- Deparsers partially implemented.