### PR TITLE
[Improvement] Refactor Commands

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -14,7 +14,8 @@ import (
 
 type apply struct{}
 
-func (a *apply) execute(folderName, database string, driver drivers.Driver) error {
+func (a *apply) execute(args []string, database string, driver drivers.Driver) error {
+	folderName := args[0]
 	return driver.ExecuteTransaction(database, func() error {
 		previousMigrationNumber, err := applications.GetPreviousMigrationNumber(driver)
 		if err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -14,9 +14,9 @@ import (
 
 type apply struct{}
 
-func (a *apply) execute(args []string, database string, driver drivers.Driver) error {
+func (a *apply) execute(args []string, databaseURL string, driver drivers.Driver) error {
 	folderName := args[0]
-	return driver.ExecuteTransaction(database, func() error {
+	return driver.ExecuteTransaction(databaseURL, func() error {
 		previousMigrationNumber, err := applications.GetPreviousMigrationNumber(driver)
 		if err != nil {
 			return err

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -12,7 +12,7 @@ import (
 var defaultDriverName = string(domain.DefaultDriver)
 
 type CommandExecutor interface {
-	execute(pathName, databaseURL string, driver drivers.Driver) error
+	execute(args []string, databaseURL string, driver drivers.Driver) error
 }
 
 type Command struct {
@@ -22,8 +22,6 @@ type Command struct {
 }
 
 func (c *Command) Execute(cmd *cobra.Command, args []string) {
-	pathName := args[0]
-
 	driver, err := drivers.GetDriver(c.driverName)
 	if err != nil {
 		log.Fatal(err)
@@ -31,7 +29,7 @@ func (c *Command) Execute(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("Driver %s started\n", c.driverName)
 
-	err = c.cmd.execute(pathName, c.databaseURL, driver)
+	err = c.cmd.execute(args, c.databaseURL, driver)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/kenji-yamane/mgr8/domain"
 	"github.com/kenji-yamane/mgr8/drivers"
 	"github.com/spf13/cobra"
 )
 
-var defaultDriver = "postgres"
+var defaultDriver = domain.Postgres
 
 type CommandExecutor interface {
 	execute(pathName, database string, driver drivers.Driver) error
@@ -23,7 +24,7 @@ type Command struct {
 func (c *Command) Execute(cmd *cobra.Command, args []string) {
 	pathName := args[0]
 
-	c.driverName = defaultDriver
+	c.driverName = string(defaultDriver)
 	if len(args) > 1 {
 		c.driverName = args[1]
 	}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -16,18 +16,13 @@ type CommandExecutor interface {
 }
 
 type Command struct {
-	driverName  string `default:"postgres"`
+	driverName  string
 	databaseURL string
 	cmd         CommandExecutor
 }
 
 func (c *Command) Execute(cmd *cobra.Command, args []string) {
 	pathName := args[0]
-
-	c.driverName = defaultDriverName
-	if len(args) > 1 {
-		c.driverName = args[1]
-	}
 
 	driver, err := drivers.GetDriver(c.driverName)
 	if err != nil {

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -12,13 +12,13 @@ import (
 var defaultDriver = domain.Postgres
 
 type CommandExecutor interface {
-	execute(pathName, database string, driver drivers.Driver) error
+	execute(pathName, databaseURL string, driver drivers.Driver) error
 }
 
 type Command struct {
-	driverName string `default:"postgres"`
-	Database   string
-	cmd        CommandExecutor
+	driverName  string `default:"postgres"`
+	databaseURL string
+	cmd         CommandExecutor
 }
 
 func (c *Command) Execute(cmd *cobra.Command, args []string) {
@@ -36,7 +36,7 @@ func (c *Command) Execute(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("Driver %s started\n", c.driverName)
 
-	err = c.cmd.execute(pathName, c.Database, driver)
+	err = c.cmd.execute(pathName, c.databaseURL, driver)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var defaultDriver = domain.Postgres
+var defaultDriverName = string(domain.DefaultDriver)
 
 type CommandExecutor interface {
 	execute(pathName, databaseURL string, driver drivers.Driver) error
@@ -24,7 +24,7 @@ type Command struct {
 func (c *Command) Execute(cmd *cobra.Command, args []string) {
 	pathName := args[0]
 
-	c.driverName = string(defaultDriver)
+	c.driverName = defaultDriverName
 	if len(args) > 1 {
 		c.driverName = args[1]
 	}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -10,32 +10,32 @@ import (
 
 var defaultDriver = "postgres"
 
-type DatabaseCommand interface {
+type CommandExecutor interface {
 	execute(pathName, database string, driver drivers.Driver) error
 }
 
-type DatabaseCmd struct {
+type Command struct {
 	driverName string `default:"postgres"`
 	Database   string
-	cmd        DatabaseCommand
+	cmd        CommandExecutor
 }
 
-func (dcmd *DatabaseCmd) Execute(cmd *cobra.Command, args []string) {
+func (c *Command) Execute(cmd *cobra.Command, args []string) {
 	pathName := args[0]
 
-	dcmd.driverName = defaultDriver
+	c.driverName = defaultDriver
 	if len(args) > 1 {
-		dcmd.driverName = args[1]
+		c.driverName = args[1]
 	}
 
-	driver, err := drivers.GetDriver(dcmd.driverName)
+	driver, err := drivers.GetDriver(c.driverName)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("Driver %s started\n", dcmd.driverName)
+	fmt.Printf("Driver %s started\n", c.driverName)
 
-	err = dcmd.cmd.execute(pathName, dcmd.Database, driver)
+	err = c.cmd.execute(pathName, c.Database, driver)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -9,7 +9,8 @@ import (
 
 type generate struct{}
 
-func (g *generate) execute(fileName, database string, driver drivers.Driver) error {
+func (g *generate) execute(args []string, database string, driver drivers.Driver) error {
+	fileName := args[0]
 	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("could not read from file: %s", err)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -9,7 +9,7 @@ import (
 
 type generate struct{}
 
-func (g *generate) execute(args []string, database string, driver drivers.Driver) error {
+func (g *generate) execute(args []string, databaseURL string, driver drivers.Driver) error {
 	fileName := args[0]
 	content, err := os.ReadFile(fileName)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ func Execute() {
 		Use:   "generate",
 		Short: "generate creates migration script based on the diff between schema versions",
 		Run:   generateCommand.Execute,
+		Args:  cobra.MinimumNArgs(1),
 	}
 	generateCmd.Flags().StringVar(&generateCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
 	generateCmd.Flags().StringVar(&generateCommand.driverName, "driver", defaultDriverName, "Driver Name")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ func Execute() {
 		Run:   applyCommand.Execute,
 		Args:  cobra.MinimumNArgs(1),
 	}
-	applyCmd.Flags().StringVar(&applyCommand.Database, "database", os.Getenv("DB_HOST"), "Database URL")
+	applyCmd.Flags().StringVar(&applyCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
 
 	validateCommand := Command{cmd: &validate{}}
 	validateCmd := &cobra.Command{
@@ -39,7 +39,7 @@ func Execute() {
 		Run:   validateCommand.Execute,
 		Args:  cobra.MinimumNArgs(1),
 	}
-	validateCmd.Flags().StringVar(&validateCommand.Database, "database", os.Getenv("DB_HOST"), "Database URL")
+	validateCmd.Flags().StringVar(&validateCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
 
 	rootCmd.AddCommand(applyCmd, generateCmd, validateCmd)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,14 +16,14 @@ func Execute() {
                 sbrubbles`,
 	}
 
-	generateCommand := DatabaseCmd{cmd: &generate{}}
+	generateCommand := Command{cmd: &generate{}}
 	generateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "generate creates migration script based on the diff between schema versions",
 		Run:   generateCommand.Execute,
 	}
 
-	applyCommand := DatabaseCmd{cmd: &apply{}}
+	applyCommand := Command{cmd: &apply{}}
 	applyCmd := &cobra.Command{
 		Use:   "apply",
 		Short: "apply runs migrations in the selected database",
@@ -32,7 +32,7 @@ func Execute() {
 	}
 	applyCmd.Flags().StringVar(&applyCommand.Database, "database", os.Getenv("DB_HOST"), "Database URL")
 
-	validateCommand := DatabaseCmd{cmd: &validate{}}
+	validateCommand := Command{cmd: &validate{}}
 	validateCmd := &cobra.Command{
 		Use:   "validate",
 		Short: "validate compares migrations sql scripts against hashing ",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ func Execute() {
 		Short: "generate creates migration script based on the diff between schema versions",
 		Run:   generateCommand.Execute,
 	}
+	generateCmd.Flags().StringVar(&generateCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
+	generateCmd.Flags().StringVar(&generateCommand.driverName, "driver", defaultDriverName, "Driver Name")
 
 	applyCommand := Command{cmd: &apply{}}
 	applyCmd := &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ func Execute() {
 		Args:  cobra.MinimumNArgs(1),
 	}
 	applyCmd.Flags().StringVar(&applyCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
+	applyCmd.Flags().StringVar(&applyCommand.driverName, "driver", defaultDriverName, "Driver Name")
 
 	validateCommand := Command{cmd: &validate{}}
 	validateCmd := &cobra.Command{
@@ -40,6 +41,7 @@ func Execute() {
 		Args:  cobra.MinimumNArgs(1),
 	}
 	validateCmd.Flags().StringVar(&validateCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
+	validateCmd.Flags().StringVar(&validateCommand.driverName, "driver", defaultDriverName, "Driver Name")
 
 	rootCmd.AddCommand(applyCmd, generateCmd, validateCmd)
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -11,7 +11,8 @@ import (
 
 type validate struct{}
 
-func (v *validate) execute(folderName, database string, driver drivers.Driver) error {
+func (v *validate) execute(args []string, database string, driver drivers.Driver) error {
+	folderName := args[0]
 	return driver.ExecuteTransaction(database, func() error {
 		previousMigrationNumber, err := applications.GetPreviousMigrationNumber(driver)
 		if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -11,9 +11,9 @@ import (
 
 type validate struct{}
 
-func (v *validate) execute(args []string, database string, driver drivers.Driver) error {
+func (v *validate) execute(args []string, databaseURL string, driver drivers.Driver) error {
 	folderName := args[0]
-	return driver.ExecuteTransaction(database, func() error {
+	return driver.ExecuteTransaction(databaseURL, func() error {
 		previousMigrationNumber, err := applications.GetPreviousMigrationNumber(driver)
 		if err != nil {
 			return err

--- a/domain/constants.go
+++ b/domain/constants.go
@@ -3,8 +3,9 @@ package domain
 type Driver string
 
 const (
-	MySql    Driver = "mysql"
-	Postgres Driver = "postgres"
+	MySql         Driver = "mysql"
+	Postgres      Driver = "postgres"
+	DefaultDriver Driver = Postgres
 
 	LogsTableName string = "migration_log"
 )


### PR DESCRIPTION
- Renames DatabaseCommand to CommandExecutor
- Renames DatabaseCmd to Command
- Renames database to databaseURL
- Adds domain const default driver
- Pass driver by flag
- Pass all args to commands instead of just the first