### PR TITLE
[Improvement] Rename column num in migration_log table to migration_number

### DIFF
--- a/drivers/mysql/parser.go
+++ b/drivers/mysql/parser.go
@@ -130,7 +130,7 @@ func (d *mySqlDriver) HasAppliedMigrationsTable() (bool, error) {
 
 func (d *mySqlDriver) CreateMigrationsLogsTable() error {
 	_, err := d.tx.Exec(`CREATE TABLE migration_log (
-		num INTEGER,
+		migration_number INTEGER,
 		type VARCHAR(4),
 		username VARCHAR(32),
 		date VARCHAR(32)
@@ -172,7 +172,7 @@ func (d *mySqlDriver) DropAppliedMigrationsTable() error {
 
 func (d *mySqlDriver) InsertIntoMigrationLog(migrationNum int, migrationType string, username string, currentDate string) error {
 	_, err := d.tx.Exec(`INSERT INTO migration_log (
-		num,
+		migration_number,
 		type,
 		username,
 		date

--- a/drivers/postgres/parser.go
+++ b/drivers/postgres/parser.go
@@ -127,7 +127,7 @@ func (d *postgresDriver) HasAppliedMigrationsTable() (bool, error) {
 
 func (d *postgresDriver) CreateMigrationsLogsTable() error {
 	_, err := d.tx.Exec(`CREATE TABLE migration_log(
-		num INTEGER,
+		migration_number INTEGER,
 		type VARCHAR(4),
 		username VARCHAR(32),
 		date VARCHAR(32)
@@ -169,7 +169,7 @@ func (d *postgresDriver) DropAppliedMigrationsTable() error {
 
 func (d *postgresDriver) InsertIntoMigrationLog(migrationNum int, migrationType string, username string, currentDate string) error {
 	_, err := d.tx.Exec(`INSERT INTO migration_log (
-		num,
+		migration_number,
 		type,
 		username,
 		date


### PR DESCRIPTION
Renames column num in migration_log table to migration_number.