### PR TITLE
make cleaner docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,17 @@ To add a new mock, add new lines to the `mock` command in the Makefile.
 
 Executing migrations with postgres driver
 ```bash
+# CLI version
 ./bin/mgr8 apply up --database=postgres://root:root@localhost:5432/core?sslmode=disable --dir=./migrations
+# Docker version
 docker run -v $PWD/migrations:/migrations -e DB_HOST=postgres://root:root@localhost:5432/core?sslmode=disable --network host -e MGR8_USERNAME=username mgr8 apply up
 ```
 
 Executing migrations with mysql driver
 ```bash
+# CLI version
 ./bin/mgr8 apply up --database=root:root@tcp\(localhost:3306\)/core --dir=./migrations --driver=mysql
+# Docker version
 docker run -v $PWD/migrations:/migrations -e DB_HOST=postgres://root:root@localhost:5432/core?sslmode=disable --network host -e MGR8_USERNAME=username mgr8 apply up --driver=mysql
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Build the docker image with `make build-docker-image`
 
 Run commands:
 ```bash
-docker run -v {{ migrations path }}:/migrations --network host -e MGR8_USERNAME={{ logs username }} mgr8 <command> --dir=./migrations --database={{ database connection string }}
+docker run -v {{ migrations path }}:/migrations --network host -e MGR8_USERNAME={{ logs username }} -e DB_HOST={{ database connection string }} mgr8 <command>
 ```
 Make sure to replace the variables surrounded by double curly braces.
 ## Develop
@@ -92,10 +92,12 @@ To add a new mock, add new lines to the `mock` command in the Makefile.
 Executing migrations with postgres driver
 ```bash
 ./bin/mgr8 apply up --database=postgres://root:root@localhost:5432/core?sslmode=disable --dir=./migrations
+docker run -v $PWD/migrations:/migrations -e DB_HOST=postgres://root:root@localhost:5432/core?sslmode=disable --network host -e MGR8_USERNAME=username mgr8 apply up
 ```
 
 Executing migrations with mysql driver
 ```bash
 ./bin/mgr8 apply up --database=root:root@tcp\(localhost:3306\)/core --dir=./migrations --driver=mysql
+docker run -v $PWD/migrations:/migrations -e DB_HOST=postgres://root:root@localhost:5432/core?sslmode=disable --network host -e MGR8_USERNAME=username mgr8 apply up --driver=mysql
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ func Execute() {
 	}
 	applyCmd.Flags().StringVar(&applyCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
 	applyCmd.Flags().StringVar(&applyCommand.driverName, "driver", defaultDriverName, "Driver Name")
-	applyCmd.Flags().StringVar(&applyCommand.migrationsDir, "dir", "", "Migrations Directory")
+	applyCmd.Flags().StringVar(&applyCommand.migrationsDir, "dir", "migrations", "Migrations Directory")
 
 	validateCommand := Command{cmd: &validate{}}
 	validateCmd := &cobra.Command{


### PR DESCRIPTION
- Pass database connection string as env variable to docker, emphasizing the command
- Set default migration directory to ./migrations, thus making unnecessary to pass it to the docker command, since the volume is mounted to /migrations.