### PR TITLE
Feat/add init check commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Execute migrations by running
 
 ### Generate migrations
 
-Mgr8 keeps a copy of the latest schema at `.mrg8/reference.sql`. Copy the first schema version to this location, or simply run `./bin/mgr8 generate init <schemafile>` which will do the same.
+Mgr8 keeps a copy of the latest schema at `.mgr8/reference.sql`. Copy the first schema version to this location, or simply run `./bin/mgr8 generate init <schemafile>` which will do the same.
 
 Then run `./bin/mgr8 generate diff <schemafile>` to generate migrations with respect to the reference file. This will also update the reference.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Execute migrations by running
 ```
 - number_of_migrations: Number of migrations to run (Optional). If not specified, runs only one.
 
+### Generate migrations
+
+Mgr8 keeps a copy of the latest schema at `.mrg8/reference.sql`. Copy the first schema version to this location, or simply run `./bin/mgr8 generate init <schemafile>` which will do the same.
+
+Then run `./bin/mgr8 generate diff <schemafile>` to generate migrations with respect to the reference file. This will also update the reference.
+
+When committing to a repository, check if the reference and the latest schema match. The command `./bin/mgr8 generate check <schemafile>` can be used, as it returns 0 if the files match.
+
+To generate an empty migration (e.g. for DML), use `./bin/mgr8 generate empty`.
+
 ## Develop
 
 ### Requirements

--- a/applications/check.go
+++ b/applications/check.go
@@ -1,0 +1,39 @@
+package applications
+
+import (
+	"errors"
+	"log"
+
+	"github.com/kenji-yamane/mgr8/infrastructure"
+)
+
+type CheckCommand interface {
+	Execute(string) error
+}
+
+type checkCommand struct {
+	fileService infrastructure.FileService
+}
+
+func NewCheckCommand(fileService infrastructure.FileService) *checkCommand {
+	return &checkCommand{fileService: fileService}
+}
+
+func (g *checkCommand) Execute(initialFile string) error {
+	schemaContent, err := g.fileService.Read(initialFile)
+	if err != nil {
+		return err
+	}
+
+	referenceContent, err := g.fileService.Read(".mgr8/reference.sql")
+	if err != nil {
+		return err
+	}
+
+	if schemaContent != referenceContent {
+		return errors.New("reference and schema dont match")
+	}
+	log.Print("Files match")
+
+	return nil
+}

--- a/applications/check.go
+++ b/applications/check.go
@@ -15,23 +15,25 @@ type checkCommand struct {
 	fileService infrastructure.FileService
 }
 
+var ErrFilesDoNotMatch = errors.New("reference and schema dont match")
+
 func NewCheckCommand(fileService infrastructure.FileService) *checkCommand {
 	return &checkCommand{fileService: fileService}
 }
 
-func (g *checkCommand) Execute(initialFile string) error {
+func (g *checkCommand) Execute(referenceFile, initialFile string) error {
 	schemaContent, err := g.fileService.Read(initialFile)
 	if err != nil {
 		return err
 	}
 
-	referenceContent, err := g.fileService.Read(".mgr8/reference.sql")
+	referenceContent, err := g.fileService.Read(referenceFile)
 	if err != nil {
 		return err
 	}
 
 	if schemaContent != referenceContent {
-		return errors.New("reference and schema dont match")
+		return ErrFilesDoNotMatch
 	}
 	log.Print("Files match")
 

--- a/applications/check_test.go
+++ b/applications/check_test.go
@@ -1,0 +1,46 @@
+package applications
+
+import (
+	"github.com/golang/mock/gomock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	infrastructure_mock "github.com/kenji-yamane/mgr8/mock/infrastructure"
+)
+
+var _ = Describe("Check Command", func() {
+	var (
+		subject *checkCommand
+	)
+
+	Context("Execute", func() {
+		var (
+			mockFileService *infrastructure_mock.MockFileService
+		)
+		BeforeEach(func() {
+			ctrl := gomock.NewController(_t)
+			mockFileService = infrastructure_mock.NewMockFileService(ctrl)
+			subject = NewCheckCommand(mockFileService)
+		})
+		When("Files match", func() {
+			It("Succeeds", func() {
+				mockFileService.EXPECT().Read("new_schema").Return("content", nil)
+				mockFileService.EXPECT().Read("reference_schema").Return("content", nil)
+				err := subject.Execute("reference_schema", "new_schema")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("Files do not match", func() {
+			It("Fails", func() {
+				mockFileService.EXPECT().Read("new_schema").Return("new_content", nil)
+				mockFileService.EXPECT().Read("reference_schema").Return("old_content", nil)
+				err := subject.Execute("reference_schema", "new_schema")
+				Expect(err).To(Equal(ErrFilesDoNotMatch))
+			})
+		})
+
+	})
+
+})

--- a/applications/empty.go
+++ b/applications/empty.go
@@ -1,0 +1,32 @@
+package applications
+
+type EmptyCommand interface {
+	Execute(string) error
+}
+
+type emptyCommand struct {
+	migrationFService MigrationFileService
+}
+
+func NewEmptyCommand(migrationFService MigrationFileService) *emptyCommand {
+	return &emptyCommand{migrationFService: migrationFService}
+}
+
+func (g *emptyCommand) Execute(migrationDir  string) error {
+	nextMigration, err := g.migrationFService.GetNextMigrationNumber(migrationDir)
+	if err != nil {
+		return err
+	}
+
+	err = g.migrationFService.WriteStatementsToFile(migrationDir, []string{}, nextMigration, "up")
+	if err != nil {
+		return err
+	}
+
+	err = g.migrationFService.WriteStatementsToFile(migrationDir, []string{}, nextMigration, "down")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/applications/empty.go
+++ b/applications/empty.go
@@ -12,7 +12,7 @@ func NewEmptyCommand(migrationFService MigrationFileService) *emptyCommand {
 	return &emptyCommand{migrationFService: migrationFService}
 }
 
-func (g *emptyCommand) Execute(migrationDir  string) error {
+func (g *emptyCommand) Execute(migrationDir string) error {
 	nextMigration, err := g.migrationFService.GetNextMigrationNumber(migrationDir)
 	if err != nil {
 		return err

--- a/applications/empty_test.go
+++ b/applications/empty_test.go
@@ -1,0 +1,49 @@
+package applications
+
+import (
+	"errors"
+
+	"github.com/golang/mock/gomock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	applications_mock "github.com/kenji-yamane/mgr8/mock/applications"
+)
+
+var _ = Describe("Empty Command", func() {
+	var (
+		subject *emptyCommand
+	)
+
+	Context("Execute", func() {
+		var (
+			mockFileService *applications_mock.MockMigrationFileService
+		)
+		BeforeEach(func() {
+			ctrl := gomock.NewController(_t)
+			mockFileService = applications_mock.NewMockMigrationFileService(ctrl)
+			subject = NewEmptyCommand(mockFileService)
+		})
+		When("Asked to execute", func() {
+			It("Succeeds", func() {
+				mockFileService.EXPECT().GetNextMigrationNumber("migrations_dir").Return(2, nil)
+				mockFileService.EXPECT().WriteStatementsToFile("migrations_dir", []string{}, 2, "up").Return(nil)
+				mockFileService.EXPECT().WriteStatementsToFile("migrations_dir", []string{}, 2, "down").Return(nil)
+				err := subject.Execute("migrations_dir")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("Fails to read file", func() {
+			It("Fails", func() {
+				expectedError := errors.New("could not get next migration")
+				mockFileService.EXPECT().GetNextMigrationNumber("migrations_dir").Return(0, expectedError)
+				err := subject.Execute("migrations_dir")
+				Expect(err).To(Equal(expectedError))
+			})
+		})
+
+	})
+
+})

--- a/applications/generate.go
+++ b/applications/generate.go
@@ -2,6 +2,7 @@ package applications
 
 import (
 	"github.com/kenji-yamane/mgr8/domain"
+	"github.com/kenji-yamane/mgr8/global"
 	"github.com/kenji-yamane/mgr8/infrastructure"
 )
 
@@ -60,5 +61,5 @@ func (g *generateCommand) Execute(parameters *GenerateParameters) error {
 		return err
 	}
 
-	return g.fService.Write(".mgr8", "reference.sql", newSchemaContent)
+	return g.fService.Write(global.ApplicationFolder, global.ReferenceFile, newSchemaContent)
 }

--- a/applications/generate.go
+++ b/applications/generate.go
@@ -21,11 +21,16 @@ type generateCommand struct {
 	migrationFService MigrationFileService
 }
 
-func NewGenerateCommand(driver domain.Driver, migrationFService MigrationFileService) *generateCommand {
-	return &generateCommand{driver: driver, migrationFService: migrationFService}
+func NewGenerateCommand(driver domain.Driver, migrationFService MigrationFileService, fService infrastructure.FileService) *generateCommand {
+	return &generateCommand{driver: driver, migrationFService: migrationFService, fService: fService}
 }
 
 func (g *generateCommand) Execute(parameters *GenerateParameters) error {
+	newSchemaContent, err := g.fService.Read(parameters.NewSchemaPath)
+	if err != nil {
+		return err
+	}
+
 	oldSchema, err := g.migrationFService.GetSchemaFromFile(parameters.OldSchemaPath)
 	if err != nil {
 		return err
@@ -55,5 +60,5 @@ func (g *generateCommand) Execute(parameters *GenerateParameters) error {
 		return err
 	}
 
-	return nil
+	return g.fService.Write(".mgr8", "reference.sql", newSchemaContent)
 }

--- a/applications/generate_test.go
+++ b/applications/generate_test.go
@@ -22,17 +22,21 @@ var _ = Describe("Generate Command", func() {
 			driver                   *domain_mock.MockDriver
 			deparser                 *domain_mock.MockDeparser
 			migrationFileServiceMock *applications_mock.MockMigrationFileService
+			fileService *infrastructure_mock.MockFileService
 		)
 		BeforeEach(func() {
 			ctrl := gomock.NewController(_t)
 			driver = domain_mock.NewMockDriver(ctrl)
 			migrationFileServiceMock = applications_mock.NewMockMigrationFileService(ctrl)
-			subject = NewGenerateCommand(driver, migrationFileServiceMock, infrastructure_mock.NewMockFileService(ctrl))
+			fileService = infrastructure_mock.NewMockFileService(ctrl)
+			subject = NewGenerateCommand(driver, migrationFileServiceMock, fileService)
 			deparser = domain_mock.NewMockDeparser(ctrl)
 
 		})
 		When("Asked to execute", func() {
 			It("Succeeds", func() {
+				fileService.EXPECT().Read("mock_new_path").Return("content", nil)
+				fileService.EXPECT().Write(".mgr8", "reference.sql", "content")
 				driver.EXPECT().Deparser().Return(deparser).Times(2)
 				migrationFileServiceMock.EXPECT().GetSchemaFromFile("mock_old_path").Return(&domain.Schema{}, nil)
 				migrationFileServiceMock.EXPECT().GetSchemaFromFile("mock_new_path").Return(&domain.Schema{}, nil)

--- a/applications/generate_test.go
+++ b/applications/generate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kenji-yamane/mgr8/domain"
 	applications_mock "github.com/kenji-yamane/mgr8/mock/applications"
 	domain_mock "github.com/kenji-yamane/mgr8/mock/domain"
+	infrastructure_mock "github.com/kenji-yamane/mgr8/mock/infrastructure"
 )
 
 var _ = Describe("Generate Command", func() {
@@ -26,7 +27,7 @@ var _ = Describe("Generate Command", func() {
 			ctrl := gomock.NewController(_t)
 			driver = domain_mock.NewMockDriver(ctrl)
 			migrationFileServiceMock = applications_mock.NewMockMigrationFileService(ctrl)
-			subject = NewGenerateCommand(driver, migrationFileServiceMock)
+			subject = NewGenerateCommand(driver, migrationFileServiceMock, infrastructure_mock.NewMockFileService(ctrl))
 			deparser = domain_mock.NewMockDeparser(ctrl)
 
 		})

--- a/applications/generate_test.go
+++ b/applications/generate_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Generate Command", func() {
 			driver                   *domain_mock.MockDriver
 			deparser                 *domain_mock.MockDeparser
 			migrationFileServiceMock *applications_mock.MockMigrationFileService
-			fileService *infrastructure_mock.MockFileService
+			fileService              *infrastructure_mock.MockFileService
 		)
 		BeforeEach(func() {
 			ctrl := gomock.NewController(_t)

--- a/applications/init.go
+++ b/applications/init.go
@@ -5,7 +5,7 @@ import (
 )
 
 type InitCommand interface {
-	Execute(string) error
+	Execute(string, string, string) error
 }
 
 type initCommand struct {
@@ -16,16 +16,16 @@ func NewInitCommand(fileService infrastructure.FileService) *initCommand {
 	return &initCommand{fileService: fileService}
 }
 
-func (g *initCommand) Execute(initialFile string) error {
+func (g *initCommand) Execute(applicationFolder, referenceFile, initialFile string) error {
 	content, err := g.fileService.Read(initialFile)
 	if err != nil {
 		return err
 	}
 
-	err = g.fileService.CreateFolderIfNotExists(".mgr8")
+	err = g.fileService.CreateFolderIfNotExists(applicationFolder)
 	if err != nil {
 		return err
 	}
 
-	return g.fileService.Write(".mgr8", "reference.sql", content)
+	return g.fileService.Write(applicationFolder, referenceFile, content)
 }

--- a/applications/init.go
+++ b/applications/init.go
@@ -1,0 +1,31 @@
+package applications
+
+import (
+	"github.com/kenji-yamane/mgr8/infrastructure"
+)
+
+type InitCommand interface {
+	Execute(string) error
+}
+
+type initCommand struct {
+	fileService infrastructure.FileService
+}
+
+func NewInitCommand(fileService infrastructure.FileService) *initCommand {
+	return &initCommand{fileService: fileService}
+}
+
+func (g *initCommand) Execute(initialFile string) error {
+	content, err := g.fileService.Read(initialFile)
+	if err != nil {
+		return err
+	}
+
+	err = g.fileService.CreateFolderIfNotExists(".mgr8")
+	if err != nil {
+		return err
+	}
+
+	return g.fileService.Write(".mgr8", "reference.sql", content)
+}

--- a/applications/init_test.go
+++ b/applications/init_test.go
@@ -1,0 +1,74 @@
+package applications
+
+import (
+	"errors"
+
+	"github.com/golang/mock/gomock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	infrastructure_mock "github.com/kenji-yamane/mgr8/mock/infrastructure"
+)
+
+var _ = Describe("Init Command", func() {
+	var (
+		subject *initCommand
+	)
+
+	Context("Execute", func() {
+		var (
+			mockFileService *infrastructure_mock.MockFileService
+			content = "file_content"
+			fileName = "file_name"
+			applicationFolder = "app_folder"
+			referenceFile = "ref_file"
+		)
+		BeforeEach(func() {
+			ctrl := gomock.NewController(_t)
+			mockFileService = infrastructure_mock.NewMockFileService(ctrl)
+			subject = NewInitCommand(mockFileService)
+		})
+		When("Asked to execute", func() {
+			It("Succeeds", func() {
+				mockFileService.EXPECT().CreateFolderIfNotExists(applicationFolder).Return(nil)
+				mockFileService.EXPECT().Read(fileName).Return(content, nil)
+				mockFileService.EXPECT().Write(applicationFolder, referenceFile, content).Return(nil)
+				err := subject.Execute(applicationFolder, referenceFile, fileName)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("Fails to read file", func() {
+			It("Fails", func() {
+				expectedError := errors.New("could not read file")
+				mockFileService.EXPECT().Read("file_name").Return("", expectedError)
+				err := subject.Execute(applicationFolder, referenceFile,"file_name")
+				Expect(err).To(Equal(expectedError))
+			})
+		})
+
+		When("Fails to write file", func() {
+			It("Fails", func() {
+				expectedError := errors.New("could not read file")
+				mockFileService.EXPECT().CreateFolderIfNotExists(applicationFolder).Return(nil)
+				mockFileService.EXPECT().Read(fileName).Return(content, nil)
+				mockFileService.EXPECT().Write(applicationFolder, referenceFile, content).Return(expectedError)
+				err := subject.Execute(applicationFolder, referenceFile,"file_name")
+				Expect(err).To(Equal(expectedError))
+			})
+		})
+
+		When("Fails to create folder", func() {
+			It("Fails", func() {
+				expectedError := errors.New("could not create folder")
+				mockFileService.EXPECT().CreateFolderIfNotExists(applicationFolder).Return(expectedError)
+				mockFileService.EXPECT().Read(fileName).Return(content, nil)
+				err := subject.Execute(applicationFolder, referenceFile,"file_name")
+				Expect(err).To(Equal(expectedError))
+			})
+		})
+
+	})
+
+})

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"log"
+	"path"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kenji-yamane/mgr8/applications"
+	"github.com/kenji-yamane/mgr8/global"
 	"github.com/kenji-yamane/mgr8/infrastructure"
 )
 
@@ -21,9 +23,10 @@ func (c *CheckCommand) Execute(cmd *cobra.Command, args []string) {
 	checkCommand := applications.NewCheckCommand(fileService)
 
 	initialFile := args[0]
-	err := checkCommand.Execute(initialFile)
+	referenceFile := path.Join(global.ApplicationFolder, global.ReferenceFile)
+
+	err := checkCommand.Execute(referenceFile, initialFile)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
-

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kenji-yamane/mgr8/applications"
+	"github.com/kenji-yamane/mgr8/infrastructure"
+)
+
+type CheckCommand struct {
+	driverName    string
+	databaseURL   string
+	migrationsDir string
+	cmd           CommandExecutor
+}
+
+func (c *CheckCommand) Execute(cmd *cobra.Command, args []string) {
+	fileService := infrastructure.NewFileService()
+	checkCommand := applications.NewCheckCommand(fileService)
+
+	initialFile := args[0]
+	err := checkCommand.Execute(initialFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -8,13 +8,10 @@ import (
 	"github.com/kenji-yamane/mgr8/infrastructure"
 )
 
-type generate struct{}
+type diff struct{}
 
-func (g *generate) execute(args []string, databaseURL string, migrationsDir string, driver domain.Driver) error {
+func (g *diff) execute(args []string, databaseURL string, migrationsDir string, driver domain.Driver) error {
 	newSchemaPath := args[0]
-
-	// TODO: get this from schemas folder
-	oldSchemaPath := args[1]
 
 	fileService := infrastructure.NewFileService()
 	clock := infrastructure.NewClock()
@@ -22,10 +19,11 @@ func (g *generate) execute(args []string, databaseURL string, migrationsDir stri
 	generateCommand := applications.NewGenerateCommand(
 		driver,
 		applications.NewMigrationFileService(fileService, applications.NewFileNameFormatter(clock), driver),
+		fileService,
 	)
 
 	err := generateCommand.Execute(&applications.GenerateParameters{
-		OldSchemaPath: oldSchemaPath,
+		OldSchemaPath: ".mgr8/reference.sql",
 		NewSchemaPath: newSchemaPath,
 		MigrationDir:  migrationsDir,
 	})

--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -8,17 +8,19 @@ import (
 	"github.com/kenji-yamane/mgr8/infrastructure"
 )
 
-type empty struct{ }
+type empty struct{
+	emptyCommand applications.EmptyCommand
+}
 
 func (c *empty) execute(args []string, databaseURL string, migrationsDir string, driver domain.Driver) error {
-	fileService := infrastructure.NewFileService()
-	clock := infrastructure.NewClock()
+	if c.emptyCommand == nil {
+		fileService := infrastructure.NewFileService()
+		clock := infrastructure.NewClock()
+		migrationFileService := applications.NewMigrationFileService(fileService, applications.NewFileNameFormatter(clock), driver)
+		c.emptyCommand = applications.NewEmptyCommand(migrationFileService)
+	}
 
-	emptyCommand := applications.NewEmptyCommand(
-		applications.NewMigrationFileService(fileService, applications.NewFileNameFormatter(clock), driver),
-	)
-
-	err := emptyCommand.Execute(migrationsDir)
+	err := c.emptyCommand.Execute(migrationsDir)
 	if err != nil {
 		log.Print(err)
 	}

--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/kenji-yamane/mgr8/applications"
+	"github.com/kenji-yamane/mgr8/domain"
+	"github.com/kenji-yamane/mgr8/infrastructure"
+)
+
+type empty struct{ }
+
+func (c *empty) execute(args []string, databaseURL string, migrationsDir string, driver domain.Driver) error {
+	fileService := infrastructure.NewFileService()
+	clock := infrastructure.NewClock()
+
+	emptyCommand := applications.NewEmptyCommand(
+		applications.NewMigrationFileService(fileService, applications.NewFileNameFormatter(clock), driver),
+	)
+
+	err := emptyCommand.Execute(migrationsDir)
+	if err != nil {
+		log.Print(err)
+	}
+	return err
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kenji-yamane/mgr8/applications"
+	"github.com/kenji-yamane/mgr8/global"
 	"github.com/kenji-yamane/mgr8/infrastructure"
 )
 
@@ -21,9 +22,8 @@ func (c *InitCommand) Execute(cmd *cobra.Command, args []string) {
 	initCommand := applications.NewInitCommand(fileService)
 
 	initialFile := args[0]
-	err := initCommand.Execute(initialFile)
+	err := initCommand.Execute(global.ApplicationFolder, global.ReferenceFile, initialFile)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
-

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kenji-yamane/mgr8/applications"
+	"github.com/kenji-yamane/mgr8/infrastructure"
+)
+
+type InitCommand struct {
+	driverName    string
+	databaseURL   string
+	migrationsDir string
+	cmd           CommandExecutor
+}
+
+func (c *InitCommand) Execute(cmd *cobra.Command, args []string) {
+	fileService := infrastructure.NewFileService()
+	initCommand := applications.NewInitCommand(fileService)
+
+	initialFile := args[0]
+	err := initCommand.Execute(initialFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultMigrationDir = "migrations"
+
 func Execute() {
 	rootCmd := &cobra.Command{
 		Use:   "mgr8",
@@ -14,16 +16,48 @@ func Execute() {
 		Long:  `Long version: mgr8 is an agnostic tool that abstracts database migration operations`,
 	}
 
-	generateCommand := Command{cmd: &generate{}}
 	generateCmd := &cobra.Command{
 		Use:   "generate",
-		Short: "generate creates migration script based on the diff between schema versions",
-		Run:   generateCommand.Execute,
-		Args:  cobra.MinimumNArgs(2),
+		Short: "generate creates migration scripts",
 	}
-	generateCmd.Flags().StringVar(&generateCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
-	generateCmd.Flags().StringVar(&generateCommand.driverName, "driver", defaultDriverName, "Driver Name")
-	generateCmd.Flags().StringVar(&generateCommand.migrationsDir, "dir", "", "Migrations Directory")
+
+	diffCommand := Command{cmd: &diff{}}
+	diffCmd := &cobra.Command{
+		Use:   "diff",
+		Short: "diff creates migration script based on the diff between schema versions",
+		Run:   diffCommand.Execute,
+		Args:  cobra.MinimumNArgs(1),
+	}
+	diffCmd.Flags().StringVar(&diffCommand.databaseURL, "database", os.Getenv("DB_HOST"), "Database URL")
+	diffCmd.Flags().StringVar(&diffCommand.driverName, "driver", defaultDriverName, "Driver Name")
+	diffCmd.Flags().StringVar(&diffCommand.migrationsDir, "dir", defaultMigrationDir, "Migrations Directory")
+
+	emptyCommand := Command{cmd: &empty{}}
+	emptyCmd := &cobra.Command{
+		Use:   "empty",
+		Short: "empty creates empty migration",
+		Run:   emptyCommand.Execute,
+	}
+	emptyCmd.Flags().StringVar(&emptyCommand.migrationsDir, "dir", defaultMigrationDir, "Migrations Directory")
+	emptyCmd.Flags().StringVar(&emptyCommand.driverName, "driver", defaultDriverName, "Driver Name")
+
+	initCommand := &InitCommand{}
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "init sets the schema as reference",
+		Run:   initCommand.Execute,
+		Args:  cobra.MinimumNArgs(1),
+	}
+
+	checkCommand := &CheckCommand{}
+	checkCmd := &cobra.Command{
+		Use:   "check",
+		Short: "check returns 0 if files match",
+		Run:   checkCommand.Execute,
+		Args:  cobra.MinimumNArgs(1),
+	}
+
+	generateCmd.AddCommand(emptyCmd, diffCmd, initCmd, checkCmd)
 
 	applyCommand := Command{cmd: &apply{}}
 	applyCmd := &cobra.Command{

--- a/domain/column_diff_test.go
+++ b/domain/column_diff_test.go
@@ -2,18 +2,18 @@ package domain_test
 
 import (
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/kenji-yamane/mgr8/domain"
 	domain_mock "github.com/kenji-yamane/mgr8/mock/domain"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Column Diff", func() {
 	var (
-		tableName string
+		tableName  string
 		columnName string
-		column *domain.Column
-		deparser *domain_mock.MockDeparser
+		column     *domain.Column
+		deparser   *domain_mock.MockDeparser
 
 		ctrl *gomock.Controller
 	)
@@ -122,7 +122,7 @@ var _ = Describe("Column Diff", func() {
 		})
 	})
 
-	AfterEach(func(){
+	AfterEach(func() {
 		ctrl.Finish()
 	})
 })

--- a/domain/table_diff_test.go
+++ b/domain/table_diff_test.go
@@ -2,12 +2,11 @@ package domain_test
 
 import (
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/kenji-yamane/mgr8/domain"
 	domain_mock "github.com/kenji-yamane/mgr8/mock/domain"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
-
 
 var _ = Describe("Table Diff", func() {
 	var (

--- a/global/constants.go
+++ b/global/constants.go
@@ -1,0 +1,6 @@
+package global
+
+const (
+	ApplicationFolder = ".mgr8"
+	ReferenceFile     = "reference.sql"
+)

--- a/infrastructure/file.go
+++ b/infrastructure/file.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,12 +18,23 @@ type FileService interface {
 	Write(migrationDir, filename, content string) error
 	Read(filename string) (string, error)
 	List(fileDirectory string) ([]MigrationFile, error)
+	CreateFolderIfNotExists(string) error
 }
 
 type fileService struct{}
 
 func NewFileService() *fileService {
 	return &fileService{}
+}
+
+func (f *fileService) CreateFolderIfNotExists(folderName string) error {
+	if _, err := os.Stat(folderName); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(folderName, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (f *fileService) Write(migrationDir, filename, content string) error {

--- a/mock/infrastructure/file_mock.go
+++ b/mock/infrastructure/file_mock.go
@@ -34,6 +34,20 @@ func (m *MockFileService) EXPECT() *MockFileServiceMockRecorder {
 	return m.recorder
 }
 
+// CreateFolderIfNotExists mocks base method.
+func (m *MockFileService) CreateFolderIfNotExists(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFolderIfNotExists", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateFolderIfNotExists indicates an expected call of CreateFolderIfNotExists.
+func (mr *MockFileServiceMockRecorder) CreateFolderIfNotExists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFolderIfNotExists", reflect.TypeOf((*MockFileService)(nil).CreateFolderIfNotExists), arg0)
+}
+
 // List mocks base method.
 func (m *MockFileService) List(fileDirectory string) ([]infrastructure.MigrationFile, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- Split `mgr8 generate` into `mgr8 generate init` (copy schema file to reference.sql), `mgr8 generate check` (checks that schema and reference match), `mgr8 generate diff` (generate actual diff migration) and `mgr8 generate empty` (generates an empty migration for things that mgr8 does not support, such as views and DML)
- Put reference file at `.mgr8/reference.sql`